### PR TITLE
Add support for MSSQL connection rerouting

### DIFF
--- a/sqlx-core/src/mssql/connection/establish.rs
+++ b/sqlx-core/src/mssql/connection/establish.rs
@@ -8,8 +8,13 @@ use crate::mssql::protocol::packet::PacketType;
 use crate::mssql::protocol::pre_login::{Encrypt, PreLogin, Version};
 use crate::mssql::{MssqlConnectOptions, MssqlConnection};
 
+enum ConnectResult {
+    Stream(MssqlStream),
+    Reroute(String, u16),
+}
+
 impl MssqlConnection {
-    pub(crate) async fn establish(options: &MssqlConnectOptions) -> Result<Self, Error> {
+    async fn connect(options: &MssqlConnectOptions) -> Result<ConnectResult, Error> {
         let mut stream: MssqlStream = MssqlStream::connect(options).await?;
 
         // Send PRELOGIN to set up the context for login. The server should immediately
@@ -57,6 +62,7 @@ impl MssqlConnection {
 
         stream.flush().await?;
 
+        let result;
         loop {
             // NOTE: we should receive an [Error] message if something goes wrong, otherwise,
             //       all messages are mostly informational (ENVCHANGE, INFO, LOGINACK)
@@ -68,10 +74,36 @@ impl MssqlConnection {
                 }
 
                 Message::Done(_) => {
+                    result = ConnectResult::Stream(stream);
+                    break;
+                }
+
+                Message::Reroute(new_server, new_port) => {
+                    result = ConnectResult::Reroute(new_server, new_port);
                     break;
                 }
 
                 _ => {}
+            }
+        }
+        Ok(result)
+    }
+
+    pub(crate) async fn establish(options: &MssqlConnectOptions) -> Result<Self, Error> {
+        let mut options = options.clone();
+        let stream;
+        loop {
+            log::debug!("mssql: Connecting to {}:{}", options.host, options.port);
+            match MssqlConnection::connect(&options).await? {
+                ConnectResult::Stream(s) => {
+                    stream = s;
+                    break;
+                }
+                ConnectResult::Reroute(host, port) => {
+                    log::debug!("mssql: Server asks us to redirect the connection; reestablishing");
+                    options.host = host;
+                    options.port = port;
+                }
             }
         }
 

--- a/sqlx-core/src/mssql/connection/stream.rs
+++ b/sqlx-core/src/mssql/connection/stream.rs
@@ -146,6 +146,10 @@ impl MssqlStream {
                                 self.transaction_descriptor = 0;
                             }
 
+                            EnvChange::RoutingInformation(host, port) => {
+                                return Ok(Message::Reroute(host, port));
+                            }
+
                             _ => {}
                         }
 

--- a/sqlx-core/src/mssql/protocol/message.rs
+++ b/sqlx-core/src/mssql/protocol/message.rs
@@ -17,6 +17,7 @@ pub(crate) enum Message {
     ReturnStatus(ReturnStatus),
     ReturnValue(ReturnValue),
     Order(Order),
+    Reroute(String, u16),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This implements support for the ENVCHANGE type 20 message from the server,
which asks the client to reconnect to the given host:port.  This makes this
client work when connecting to Azure SQL from within the Azure network.